### PR TITLE
Reset the queuePos to -1 on queue change

### DIFF
--- a/Persephone/DataSources/QueueDataSource.swift
+++ b/Persephone/DataSources/QueueDataSource.swift
@@ -18,6 +18,8 @@ class QueueDataSource: NSObject, NSOutlineViewDataSource {
   let pauseIcon = NSImage(named: "pauseButton")
 
   func updateQueue(_ queue: [MPDClient.Song]) {
+    queuePos = -1
+    
     self.queue = queue.enumerated().map { index, song in
       SongItem(song: song, queuePos: index, isPlaying: index == queuePos)
     }


### PR DESCRIPTION
This avoids the index ever being out of range which is what was causing
the crash. The queuePos gets updated straight after the queue anyway.