### PR TITLE
Maintain relative scroll position on resize

### DIFF
--- a/Persephone/Controllers/AlbumViewController.swift
+++ b/Persephone/Controllers/AlbumViewController.swift
@@ -44,6 +44,15 @@ class AlbumViewController: NSViewController,
     albumCollectionView.collectionViewLayout?.invalidateLayout()
   }
 
+  override func viewDidLayout() {
+    super.viewDidLayout()
+
+    guard let layout = albumCollectionView.collectionViewLayout as? AlbumViewLayout
+      else { return }
+
+    layout.setScrollPosition()
+  }
+
   @objc func updateAlbums(_ notification: Notification) {
     guard let albums = notification.userInfo?[Notification.albumsKey] as? [MPDClient.Album]
       else { return }

--- a/Persephone/Layouts/AlbumViewLayout.swift
+++ b/Persephone/Layouts/AlbumViewLayout.swift
@@ -11,6 +11,7 @@ import Cocoa
 class AlbumViewLayout: NSCollectionViewFlowLayout {
   let maxItemWidth: CGFloat = 180
   let albumInfoHeight: CGFloat = 39
+  var scrollPosition: CGFloat = 0
 
   required init?(coder aDecoder: NSCoder) {
     super.init()
@@ -35,6 +36,10 @@ class AlbumViewLayout: NSCollectionViewFlowLayout {
     var divider: CGFloat = 1
     var itemWidth: CGFloat = 0
 
+    if let scrollView = collectionView.enclosingScrollView {
+      scrollPosition = scrollView.documentVisibleRect.minY / collectionView.bounds.height
+    }
+
     repeat {
       let totalPaddingWidth = sectionInset.left + sectionInset.right
       let totalGutterWidth = (divider - 1) * (minimumInteritemSpacing)
@@ -45,5 +50,12 @@ class AlbumViewLayout: NSCollectionViewFlowLayout {
     let itemHeight = itemWidth + albumInfoHeight
 
     itemSize = NSSize(width: itemWidth, height: itemHeight)
+  }
+
+  func setScrollPosition() {
+    guard let collectionView = collectionView
+      else { return }
+
+    collectionView.scroll(NSPoint(x: 0, y: scrollPosition * collectionView.bounds.height))
   }
 }

--- a/Persephone/Views/AlbumItemView.swift
+++ b/Persephone/Views/AlbumItemView.swift
@@ -43,7 +43,7 @@ class AlbumItemView: NSView {
 
     NotificationCenter.default.addObserver(
       self,
-      selector: #selector(viewWillScroll(_:)),
+      selector: #selector(viewDidScroll(_:)),
       name: NSScrollView.didLiveScrollNotification,
       object: nil
     )
@@ -57,6 +57,10 @@ class AlbumItemView: NSView {
 
   @objc func viewWillScroll(_ notification: Notification) {
     hidePlayButton()
+  }
+
+  @objc func viewDidScroll(_ notification: Notification) {
+    viewWillScroll(notification)
   }
 
   override func resize(withOldSuperviewSize oldSize: NSSize) {

--- a/Persephone/Views/AlbumItemView.swift
+++ b/Persephone/Views/AlbumItemView.swift
@@ -60,7 +60,7 @@ class AlbumItemView: NSView {
   }
 
   @objc func viewDidScroll(_ notification: Notification) {
-    viewWillScroll(notification)
+    hidePlayButton()
   }
 
   override func resize(withOldSuperviewSize oldSize: NSSize) {


### PR DESCRIPTION
By default, the collection view keeps the scroll position in exactly the same place as the view resizes. This causes the albums to jump about a lot as they relayout. This PR recalculates the scroll position based on the percentage the view is scrolled down. This makes for a much less janky experience.