### PR TITLE
Fix incorrect display of album art

### DIFF
--- a/Persephone/MPDClient/Models/MPDSong.swift
+++ b/Persephone/MPDClient/Models/MPDSong.swift
@@ -52,8 +52,16 @@ extension MPDClient {
     var album: MPDAlbum {
       return MPDAlbum(
         title: getTag(.album),
-        artist: getTag(.albumArtist)
+        artist: artist
       )
+    }
+
+    var artist: String {
+      if getTag(.albumArtist) != "" {
+        return getTag(.albumArtist)
+      } else {
+        return getTag(.artist)
+      }
     }
 
     func getTag(_ tagType: TagType) -> String {


### PR DESCRIPTION
Some tracks do not have an album artist, so the artist string was blank in the cover hash. This meant that albums with the same name by different artists would get the same artwork.