### PR TITLE
Fix aspect ratio problems when scaling images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.1-alpha - 2019-04-01
+
+### Changed
+
+- Tweaked the QoS of the artwork queue for better performance
+
 ## 0.11.0-alpha - 2019-04-01
 
 ### Added

--- a/Persephone/Extensions/NSImage.swift
+++ b/Persephone/Extensions/NSImage.swift
@@ -15,7 +15,17 @@ extension NSImage {
   static let defaultCoverArt = NSImage(named: "blankAlbum")
 
   func toFitBox(size: NSSize) -> NSImage {
-    let newImage = NSImage(size: size)
+    var newSize: NSSize = NSSize.zero
+    let aspectRatio = self.size.width / self.size.height
+    let boxAspectRatio = size.width / size.height
+
+    if aspectRatio > boxAspectRatio {
+      newSize = NSSize(width: size.width, height: size.width / aspectRatio)
+    } else {
+      newSize = NSSize(width: size.height * aspectRatio, height: size.height)
+    }
+
+    let newImage = NSImage(size: newSize)
     newImage.lockFocus()
     self.draw(in: newImage.alignmentRect)
     newImage.unlockFocus()

--- a/Persephone/Resources/AlbumViewItem.xib
+++ b/Persephone/Resources/AlbumViewItem.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -37,7 +37,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <imageView identifier="albumArtwork" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Kfb-8f-ean">
+                <imageView identifier="albumArtwork" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Kfb-8f-ean">
                     <rect key="frame" x="0.0" y="39" width="128" height="128"/>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="blankAlbum" id="FsA-JX-BFh"/>
                 </imageView>


### PR DESCRIPTION
The `.fitToBox` method was not keeping the aspect ratio when scaling
images. Now it does.