### PR TITLE
Improve album art display

### DIFF
--- a/Persephone/Components/Browser/Album Browser/AlbumViewItem.swift
+++ b/Persephone/Components/Browser/Album Browser/AlbumViewItem.swift
@@ -28,7 +28,7 @@ class AlbumViewItem: NSCollectionViewItem {
     albumCoverView.layer?.masksToBounds = true
 
     albumCoverBox.wantsLayer = true
-    albumCoverBox.layer?.cornerRadius = 6
+    albumCoverBox.layer?.cornerRadius = 7
     albumCoverBox.layer?.borderWidth = 5
 
     setAppearance(selected: false)

--- a/Persephone/Components/Browser/Album Browser/AlbumViewItem.swift
+++ b/Persephone/Components/Browser/Album Browser/AlbumViewItem.swift
@@ -60,17 +60,21 @@ class AlbumViewItem: NSCollectionViewItem {
   }
 
   func setAppearance(selected isSelected: Bool) {
+    guard let viewLayer = albumCoverView.layer,
+      let boxLayer = albumCoverBox.layer
+      else { return }
+
     if #available(OSX 10.14, *) {
       let darkMode = NSApp.effectiveAppearance.bestMatch(from:
         [.darkAqua, .aqua]) == .darkAqua
 
-      albumCoverView.layer?.borderColor = darkMode ? .albumBorderColorDark : .albumBorderColorLight
-      albumCoverBox.layer?.borderColor = isSelected ? NSColor.controlAccentColor.cgColor : CGColor.clear
-      albumCoverBox.layer?.backgroundColor = isSelected ? NSColor.controlAccentColor.cgColor : CGColor.clear
+      viewLayer.borderColor = darkMode ? .albumBorderColorDark : .albumBorderColorLight
+      boxLayer.borderColor = isSelected ? NSColor.controlAccentColor.cgColor : CGColor.clear
+      boxLayer.backgroundColor = albumCoverBox.layer?.borderColor
     } else {
-      albumCoverView.layer?.borderColor = .albumBorderColorLight
-      albumCoverBox.layer?.borderColor = isSelected ? NSColor.selectedControlColor.cgColor : CGColor.clear
-      albumCoverBox.layer?.backgroundColor = isSelected ? NSColor.selectedControlColor.cgColor : CGColor.clear
+      viewLayer.borderColor = .albumBorderColorLight
+      boxLayer.borderColor = isSelected ? NSColor.selectedControlColor.cgColor : CGColor.clear
+      boxLayer.backgroundColor = albumCoverBox.layer?.borderColor
     }
   }
 

--- a/Persephone/Components/Browser/Album Browser/AlbumViewItem.swift
+++ b/Persephone/Components/Browser/Album Browser/AlbumViewItem.swift
@@ -22,8 +22,10 @@ class AlbumViewItem: NSCollectionViewItem {
     super.viewDidLoad()
 
     albumCoverView.wantsLayer = true
-    albumCoverView.layer?.cornerRadius = 3
+    albumCoverView.layer?.backgroundColor = NSColor.black.cgColor
+    albumCoverView.layer?.cornerRadius = 4
     albumCoverView.layer?.borderWidth = 1
+    albumCoverView.layer?.masksToBounds = true
 
     albumCoverBox.wantsLayer = true
     albumCoverBox.layer?.cornerRadius = 5

--- a/Persephone/Components/Browser/Album Browser/AlbumViewItem.swift
+++ b/Persephone/Components/Browser/Album Browser/AlbumViewItem.swift
@@ -14,7 +14,7 @@ class AlbumViewItem: NSCollectionViewItem {
 
   override var isSelected: Bool {
     didSet {
-      albumCoverBox.layer?.borderWidth = isSelected ? 5 : 0
+      setAppearance(selected: isSelected)
     }
   }
 
@@ -28,14 +28,14 @@ class AlbumViewItem: NSCollectionViewItem {
     albumCoverView.layer?.masksToBounds = true
 
     albumCoverBox.wantsLayer = true
-    albumCoverBox.layer?.cornerRadius = 5
-    albumCoverBox.layer?.borderWidth = 0
+    albumCoverBox.layer?.cornerRadius = 6
+    albumCoverBox.layer?.borderWidth = 5
 
-    setAppearance()
+    setAppearance(selected: false)
 
     if #available(OSX 10.14, *) {
       observer = NSApp.observe(\.effectiveAppearance) { (app, _) in
-        self.setAppearance()
+        self.setAppearance(selected: false)
       }
     }
   }
@@ -59,16 +59,18 @@ class AlbumViewItem: NSCollectionViewItem {
     }
   }
 
-  func setAppearance() {
+  func setAppearance(selected isSelected: Bool) {
     if #available(OSX 10.14, *) {
       let darkMode = NSApp.effectiveAppearance.bestMatch(from:
         [.darkAqua, .aqua]) == .darkAqua
 
       albumCoverView.layer?.borderColor = darkMode ? .albumBorderColorDark : .albumBorderColorLight
-      albumCoverBox.layer?.borderColor = NSColor.controlAccentColor.cgColor
+      albumCoverBox.layer?.borderColor = isSelected ? NSColor.controlAccentColor.cgColor : CGColor.clear
+      albumCoverBox.layer?.backgroundColor = isSelected ? NSColor.controlAccentColor.cgColor : CGColor.clear
     } else {
       albumCoverView.layer?.borderColor = .albumBorderColorLight
-      albumCoverBox.layer?.borderColor = NSColor.selectedControlColor.cgColor
+      albumCoverBox.layer?.borderColor = isSelected ? NSColor.selectedControlColor.cgColor : CGColor.clear
+      albumCoverBox.layer?.backgroundColor = isSelected ? NSColor.selectedControlColor.cgColor : CGColor.clear
     }
   }
 

--- a/Persephone/Components/Browser/Album Detail/AlbumDetailView.swift
+++ b/Persephone/Components/Browser/Album Detail/AlbumDetailView.swift
@@ -9,6 +9,7 @@
 import AppKit
 
 class AlbumDetailView: NSViewController {
+  var observer: NSKeyValueObservation?
   var album: Album?
   var dataSource = AlbumTracksDataSource()
 
@@ -30,10 +31,17 @@ class AlbumDetailView: NSViewController {
     albumTracksView.columnAutoresizingStyle = .sequentialColumnAutoresizingStyle
 
     albumCoverView.wantsLayer = true
-    albumCoverView.layer?.cornerRadius = 5
+    albumCoverView.layer?.backgroundColor = NSColor.black.cgColor
+    albumCoverView.layer?.cornerRadius = 6
     albumCoverView.layer?.borderWidth = 1
+    albumCoverView.layer?.masksToBounds = true
     setAppearance()
 
+    if #available(OSX 10.14, *) {
+      observer = NSApp.observe(\.effectiveAppearance) { (app, _) in
+        self.setAppearance()
+      }
+    }
   }
 
   override func viewWillAppear() {


### PR DESCRIPTION
The corners of the album covers were extending beyond the rounded corners of the box, and the selection border was not taking that into account.

Before:

<img width="172" alt="image" src="https://user-images.githubusercontent.com/165531/68044515-e00cfc80-fcad-11e9-8f8c-76de34eb58c5.png"><img width="172" alt="Screenshot 2019-11-01 at 13 45 54" src="https://user-images.githubusercontent.com/165531/68044568-f74bea00-fcad-11e9-96eb-bc6b10d99692.png">

After:

<img width="171" alt="image" src="https://user-images.githubusercontent.com/165531/68044636-18143f80-fcae-11e9-84e4-c3ccbedc6c42.png"><img width="172" alt="image" src="https://user-images.githubusercontent.com/165531/68044714-3d08b280-fcae-11e9-97fc-fb777834332b.png">


