### PR TITLE
Move the handle idle command into the command queue

### DIFF
--- a/Shared/MPDClient/Extensions/MPDClient+Command.swift
+++ b/Shared/MPDClient/Extensions/MPDClient+Command.swift
@@ -158,7 +158,7 @@ extension MPDClient {
 
     let commandOperation = BlockOperation() { [unowned self] in
       self.sendCommand(command: command, userData: userData)
-
+  
       if self.checkError() {
         self.idle(forceIdle)
       }

--- a/Shared/MPDClient/MPDClient.swift
+++ b/Shared/MPDClient/MPDClient.swift
@@ -21,8 +21,6 @@ class MPDClient {
   var queue: [MPDSong] = []
 
   let commandQueue = OperationQueue()
-  
-  let idleLock = NSLock()
 
   init(withDelegate delegate: MPDClientDelegate?) {
     commandQueue.maxConcurrentOperationCount = 1


### PR DESCRIPTION
My theory is that it's ok to send the `noidle` synchronously but the
subsequent handling of the idle response should be on the command queue.
My hope is that this fixes issues with less than perfect network
connections (and also very occasionally seen on good networks).

This also simplifies the code somewhat and removes the need for the lock.